### PR TITLE
add missing src/ directory to implementation files example

### DIFF
--- a/src/site/docs/pub-package-manager/package-layout.markdown
+++ b/src/site/docs/pub-package-manager/package-layout.markdown
@@ -150,7 +150,7 @@ can (and should) still use `"package:"` to import them. This is perfectly
 legit:
 
 {% highlight dart %}
-#import("package:enchilada/lib/src/beans.dart");
+#import("package:enchilada/src/beans.dart");
 {% endhighlight %}
 
 ## Tests


### PR DESCRIPTION
Import statement (and full example layout at top of page) show beans.dart and queso.dart in lib/src/ not just lib/
