### PR TITLE
Fixed a sample code import error in web components article

### DIFF
--- a/src/site/articles/dart-web-components/index.markdown
+++ b/src/site/articles/dart-web-components/index.markdown
@@ -432,7 +432,7 @@ take the click-count example above and make it a component as follows:
       </div>
     </template>
     <script type="application/dart">
-      import 'package:web_components/web_component.dart';
+      import 'package:web_components/web_components.dart';
 
       class CounterComponent extends WebComponent {
         int count = 0;


### PR DESCRIPTION
Fixed a wrong import in the web component sample code. Changed web_component.dart to web_components.dart by adding a 's' in the end. Related bug: https://github.com/dart-lang/dart-web-components/issues/199
