### PR TITLE
Make comment about output accurately reflect output.

### DIFF
--- a/src/site/articles/feet-wet-streams/code/feet_wet_streams.dart
+++ b/src/site/articles/feet-wet-streams/code/feet_wet_streams.dart
@@ -211,7 +211,7 @@ singleErrorWithCatch() {
       .single  // will fail - there is more than one value in the stream
       .then((value) => print("single value: $value"))
       .catchError((err) => print("Expected Error: $err")); // catch any error in the then()
-      // output: Bad State: More than one element
+      // output: Expected Error: Bad State: More than one element
       // END(catch_error)
 }
 


### PR DESCRIPTION
Fixes a minor issue with the "Getting Your Feet Wet with Streams" article: a comment describing the output of some code did not accurately reflect what the code outputs.
