### PR TITLE
Small type in declaration

### DIFF
--- a/src/site/articles/json-web-service/code/json_saving_objects_test.dart
+++ b/src/site/articles/json-web-service/code/json_saving_objects_test.dart
@@ -2,7 +2,7 @@ import 'dart:html';
 HttpRequest request;
 
 void saveData() {
-  HttpRequest req = new HttpRequest(); // create a new XHR
+  HttpRequest request = new HttpRequest(); // create a new XHR
   
   // add an event handler that is called when the request finishes
   request.onReadyStateChange.listen((_) {


### PR DESCRIPTION
There's a small typo. The request object was defined as 'req' but used as 'request'. Fixed in definition - now it defined as: HttpRequest request = new HttpRequest();
