### PR TITLE
added the link to Language Specification back to the menu

### DIFF
--- a/src/site/_includes/header.html
+++ b/src/site/_includes/header.html
@@ -93,6 +93,7 @@
               <ul class="dropdown-menu">
                 <li><a href="/docs/">Programmer's Guide</a></li>
                 <li><a href="http://api.dartlang.org">API Reference</a></li>
+                <li><a href="/docs/spec">Language Specification</a></li>
 
                 <li class="divider"></li>
                 <li><a href="/docs/cookbook/">Dart Cookbook (Beta)</a></li>


### PR DESCRIPTION
This change adds a link to the Language Specification back to the menu (header). I realize that I placed it in a prominent place, but I spent some time trying various positions and I only liked this one. Feel free to put it elsewhere -- my main point is that link to the spec should really be there.
