### PR TITLE
Fixing Web UI article: replacing window.setInterval() with Timer.periodic() constructor

### DIFF
--- a/src/site/articles/web-ui/index.markdown
+++ b/src/site/articles/web-ui/index.markdown
@@ -151,14 +151,15 @@ the UI.
   <div>Hello counter: {{count}}</div>
   <script type="application/dart">
     import 'dart:html';
+    import 'dart:async';
     import 'package:web_ui/watcher.dart' as watchers;
     int count;
     main() {
       count = 0;
-      window.setInterval(() {
+      new Timer.periodic(const Duration(seconds: 1), (_) {
         count++;
         watchers.dispatch();
-      }, 1000);
+      });
     }
   </script>
 </body></html>


### PR DESCRIPTION
Second example of "One-way data binding" section of the Web UI article did not comply with the linked full code [1], and it wasn't working anymore [2]:

```
Class 'Window' has no instance method 'setInterval'.

NoSuchMethodError : method not found: 'setInterval'
Receiver: Instance of 'Window'
Arguments: [Closure: () => dynamic, 1000]
```

(SDK 0.6.17.2_r26023)

References:
[1] https://github.com/dart-lang/web-ui/blob/master/example/explainer/counter.html
[2] [Breaking change: Removal of window.setTimeout and window.setInterval](https://groups.google.com/a/dartlang.org/forum/#!msg/misc/9h7pxLbv5fU/4pn9PJUvoTAJ)
