### PR TITLE
Get rid of gradients in the style guide.

### DIFF
--- a/src/site/scss/_syntax.scss
+++ b/src/site/scss/_syntax.scss
@@ -1,37 +1,11 @@
 div.bad pre.prettyprint {
   border-radius: 5px;
-
-  background-image: linear-gradient(bottom, rgb(255,242,242) 16%, rgb(255,204,204) 86%);
-  background-image: -o-linear-gradient(bottom, rgb(255,242,242) 16%, rgb(255,204,204) 86%);
-  background-image: -moz-linear-gradient(bottom, rgb(255,242,242) 16%, rgb(255,204,204) 86%);
-  background-image: -webkit-linear-gradient(bottom, rgb(255,242,242) 16%, rgb(255,204,204) 86%);
-  background-image: -ms-linear-gradient(bottom, rgb(255,242,242) 16%, rgb(255,204,204) 86%);
-
-  background-image: -webkit-gradient(
-    linear,
-    left bottom,
-    left top,
-    color-stop(0.16, rgb(255,242,242)),
-    color-stop(0.86, rgb(255,204,204))
-  );
+  background-color: #fff8f8;
 }
 
 div.good pre.prettyprint {
   border-radius: 5px;
-
-  background-image: linear-gradient(bottom, rgb(243,255,240) 16%, rgb(213,255,204) 86%);
-  background-image: -o-linear-gradient(bottom, rgb(243,255,240) 16%, rgb(213,255,204) 86%);
-  background-image: -moz-linear-gradient(bottom, rgb(243,255,240) 16%, rgb(213,255,204) 86%);
-  background-image: -webkit-linear-gradient(bottom, rgb(243,255,240) 16%, rgb(213,255,204) 86%);
-  background-image: -ms-linear-gradient(bottom, rgb(243,255,240) 16%, rgb(213,255,204) 86%);
-
-  background-image: -webkit-gradient(
-    linear,
-    left bottom,
-    left top,
-    color-stop(0.16, rgb(243,255,240)),
-    color-stop(0.86, rgb(213,255,204))
-  );
+  background-color: #f8fff8;
 }
 
 .good pre.prettyprint:before {


### PR DESCRIPTION
As discussed in some mail around one year ago, I find that the gradients of the style guide, although nice, make it harder to read than http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml for instance. As discussed in the same mail, I also never got the website to compile on my Linux machine but @sethladd told me to submit the changes without testing since they were simple.

So there it is, one year later :) I used the colors of http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml but I can't guarantee it looks good since I couldn't test it on my machine.
