### PR TITLE
editor-version.js: Fixed broken latest stable version calculation.

### DIFF
--- a/src/site/js/editor-version.js
+++ b/src/site/js/editor-version.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
       url: 'http://dartlang.org/editor/update/channels/' + channel + '/latest/VERSION',
       dataType: "json",
       success: function(data) {
-        updatePlaceholders(buildType, data['revision']);
+        updatePlaceholders(channel, data['revision']);
       },
       error: function(xhr, textStatus, errorThrown) {
         console.log(textStatus);


### PR DESCRIPTION
The version calculation didn't work on my machine while testing, due to XHR headers not set on dartlang.org.
