### PR TITLE
Toc hover issue 202

### DIFF
--- a/src/site/css/dart-style.css
+++ b/src/site/css/dart-style.css
@@ -1276,3 +1276,9 @@ dd{
 }
 
 .remark {display:none;}
+
+/* Make the hovering behavior consistent in TOC */
+#markdown-toc * {
+  list-style: none;
+  text-decoration:none;
+}


### PR DESCRIPTION
https://github.com/dart-lang/dartlang.org/issues/202

Underline removed on hover. 

![screen shot 2013-11-13 at 11 00 18 pm](https://f.cloud.github.com/assets/654526/1538976/74547cfc-4cfa-11e3-9c05-110106d22850.png)
