### PR TITLE
Fixing formatting in style guide rule heading

### DIFF
--- a/src/site/articles/style-guide/index.markdown
+++ b/src/site/articles/style-guide/index.markdown
@@ -446,8 +446,7 @@ Map<int, List<Person>> groupByZip(Iterable<Person> people) {
 {% endprettify %}
 </div>
 
-#### PREFER using `double` or `int` instead of `num` for parameter type
-annotations in performance sensitive code.
+#### PREFER using `double` or `int` instead of `num` for parameter type annotations in performance sensitive code.
 
 Monomorphic call sites (sites that have stable input types)
 can be optimized much easier than polymorphic call sites (sites that have


### PR DESCRIPTION
The heading was broken across multiple lines, causing the issue.

Currently broken here: https://www.dartlang.org/articles/style-guide/#prefer-using-double-or-int-instead-of-num-for-parameter-type
