### PR TITLE
Add Chinese mirror sites.

### DIFF
--- a/src/site/support/index.html
+++ b/src/site/support/index.html
@@ -95,6 +95,21 @@ Track the Dart project and join the conversation in a variety of ways.
       Learn how to <a href="https://code.google.com/p/dart/wiki/Contributing">contribute
       to the core SDK</a>.
     </p>
-
+    
+    <h2> For Chinese Developers </h2>
+    <p> 下面是一些中文开发资源 。</p>
+    <ul>
+      
+      <li><a href="http://www.dartlang.cc">www.dartlang.cc</a><br>
+       Dart 中文网站。</li>
+      <li><a href="http://news.dartlang.cc/">news.dartlang.cc</a><br>
+                      订阅 Dart 中文新闻。</li>
+      <li><a href="http://api.dartlang.cc">api.dartlang.cc</a><br>
+       Dart API 中国镜像。</li>
+      <li><a href="http://pub.dartlang.cc">pub.dartlang.cc</a><br>
+       Dart Pub 中国镜像。</li>
+      <li><a href="http://forum.dartlang.cc">forum.dartlang.cc</a><br>
+       Dart 中文讨论区。</li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
Because of the Great
Firewall(http://en.wikipedia.org/wiki/Golden_Shield_Project), sometimes
can not access the GAE and Google Storage at Chinese Mainland. So we
build some mirror sites in China and translate some materials to Chinese
, let the Chinese much easier to learn Dart and use Pub. 
(Most of the time in China are unable to access 
https://commondatastorage.googleapis.com.)
