### PR TITLE
Fix a typo in a link.

### DIFF
--- a/src/site/articles/dart-unit-tests/index.markdown
+++ b/src/site/articles/dart-unit-tests/index.markdown
@@ -114,7 +114,7 @@ expect(actualValue, expectedValueMatcher);
 {% endprettify %}
 
 `expect()` is modelled on third-generation assert libraries like
-[Hamcrest](http://http//code.google.com/p/hamcrest/).
+[Hamcrest](http://code.google.com/p/hamcrest/).
 It also borrows some ideas
 from Ladislav Thon's early Dart matcher library, darmatch.
 


### PR DESCRIPTION
Remove the extra "http//" in the destination URL.
