### PR TITLE
Fixed a typo; fixed blockquote rendering

### DIFF
--- a/src/site/articles/why-dart-types/index.markdown
+++ b/src/site/articles/why-dart-types/index.markdown
@@ -86,7 +86,8 @@ print(cow.moo());
 {% endprettify %}
 
 An up-assignment like [1] is always valid, so we make them pass static type checking.  A down-assignment could be valid, as [2] is, or invalid.  Because down-assignments <em>may</em> be valid and Dart is optimistic that you know what you're doing, we make them pass static checking too.  This gives us the assignment rule in the language spec:
-<blockquote>A type T <em>may be assigned to</em> a type S, written  T &hArr; S, iff either T &lt;: S or S &lt;: T.</blockquote>
+<blockquote>A type T <em>may be assigned to</em> a type S, written  T &hArr; S, iff either T &lt;: S or S &lt;: T.
+</blockquote>
 
 ### Here we are, unsound
 


### PR DESCRIPTION
Closing tag `</blockquote>` needs to be in a separate line for Markdown to render properly.
- Before:
  ![screenshot from 2014-02-21 21 57 29](https://f.cloud.github.com/assets/342945/2234600/32af9554-9b3b-11e3-8474-f336be022860.png)
- After:
  ![screenshot from 2014-02-21 21 57 40](https://f.cloud.github.com/assets/342945/2234606/3973e444-9b3b-11e3-8b1c-65f3e943fffa.png)
