### PR TITLE
Add Rollbar to "Who Uses Dart"

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -46,6 +46,9 @@ Google internal sales tool
 [Codeship](https://www.codeship.io/)
 : Continuous integration with support for Dart.
 
+[Rollbar](https://rollbar.com/)
+: Error reporting service with support for Dart (including source maps).
+
 [Adobe](http://blogs.adobe.com/flashpro/2013/05/16/toolkit-for-dart-flash-pro/)
 : Flash Pro can export to Dart/HTML5/CSS.
 


### PR DESCRIPTION
Hi Dart team,

[Rollbar](https://rollbar.com) now plays nicely with Dart, thanks to [rollbar.dart](https://github.com/Mixbook/rollbar.dart) by @astashov. I saw some other services that work with Dart in this list, hence this PR. If that's not what this list is for, feel free to close this request.

Cheers,

Brian
