### PR TITLE
Fixed issue where loc blocks are generated incorrectly

### DIFF
--- a/src/site/_plugins/sitemap_generator.rb
+++ b/src/site/_plugins/sitemap_generator.rb
@@ -80,7 +80,7 @@ module Jekyll
     end
 
     def location_on_server(my_url)
-      location = "#{my_url}#{@dir}#{url}"
+      location = "#{my_url}#{url}"
       location.gsub(/index.html$/, "")
     end
   end


### PR DESCRIPTION
This is a fix for [issue 334](https://github.com/dart-lang/dartlang.org/issues/334), hence the branch name.

Michael Levins [sitemap_plugin.rb](https://github.com/kinnetica/jekyll-plugins/blob/master/sitemap_generator.rb) (linked from the official [jekyll site](http://jekyllrb.com/docs/plugins/)) suggests that the @dir attribute isn't needed in location_on_server. 

I've tested the sitemap generation locally with success.
