### PR TITLE
Remove accidental text from download.markdown

### DIFF
--- a/src/site/tools/download.markdown
+++ b/src/site/tools/download.markdown
@@ -153,7 +153,6 @@ You can also download the latest **Dev Channel** build of
 <span class="linux">
 You can also download the latest **Dev Channel** build of
 <a href="http://storage.googleapis.com/dart-archive/channels/dev/release/latest/dartium/dartium-linux-x64-release.zip">Dartium for Linux 64-bit</a>
-dartium-linux-x64-release.zip
 or
 <a href="http://storage.googleapis.com/dart-archive/channels/dev/release/latest/dartium/dartium-linux-ia32-release.zip">Dartium for Linux 32-bit</a>.
 </span>


### PR DESCRIPTION
Fixes [Issue 18905](https://code.google.com/p/dart/issues/detail?id=18905)
