### PR TITLE
Who Uses Dart: Rename 'Spark' to 'Chrome Dev Editor'

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -92,7 +92,7 @@ Google internal sales tool
 : Specialized in the design and implementation of online campaigns. Uses
   Dart for interactive experiences.
 
-[Spark](https://github.com/dart-lang/spark)
+[Chrome Dev Editor](https://github.com/dart-lang/chromedeveditor)
 : An open source IDE for developing Chrome packaged apps as well as Dart web apps.
   Written in Dart, as a Chrome App, and uses Polymer for the UI.
 


### PR DESCRIPTION
Renames Spark to 'Chrome Dev Editor'
