### PR TITLE
Adding a[name]:target to also have padding top, for Dart Tour

### DIFF
--- a/src/site/css/dart-style.css
+++ b/src/site/css/dart-style.css
@@ -21,7 +21,8 @@ a:hover {
 
 /* place link target below the header bar. The top padding should match the
 header height */
-.has-permalink:target {
+.has-permalink:target,
+a[name]:target {
   padding-top: 65px;
 }
 


### PR DESCRIPTION
This fixes [dartbug 7965](https://code.google.com/p/dart/issues/detail?id=7965) (I've only tested in Chrome Dev Tools). A different fix might be to add the .has-permalink class to each header...
