### PR TITLE
Fix the Unit Testing article re: Async

### DIFF
--- a/src/site/articles/dart-unit-tests/index.markdown
+++ b/src/site/articles/dart-unit-tests/index.markdown
@@ -632,6 +632,9 @@ You can also make a test asynchronous by returning a Future.
 The test will only be considered complete after the Future is complete.
 You can combine returning a Future with calls to `expectAsync`, if necessary.
 
+Learn more about the aynchronous unit test functions from the
+[unittest documentation](http://www.dartdocs.org/documentation/unittest/latest).
+
 
 ## Matchers
 


### PR DESCRIPTION
I've updated the [Asynchronous tests](https://www.dartlang.org/articles/dart-unit-tests/#asynchronous-tests) section of the Unit Testing with Dart article with the following:
- [x] code format a few function names in text.
- [x] fix references to `expectAsync0`, `expectAsyncN`, and `expectAsyncUntilN` since they were renamed ([announcement](https://groups.google.com/a/dartlang.org/forum/#!topic/misc/AWCX_ZjDxw4)).
- [x] entirely delete references to `protectAsyncN` and `guardAsync` as they were removed (see above announcement).
- [ ] add new text regarding how exceptions are handled in callbacks to replace the `protectAsyncN` paragraph.
- [x] add links to the [unittest API documentation](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/unittest/unittest). But is that not something we do in articles?
