### PR TITLE
Change tools/editor/troubleshoot's anchors to use article/api-style anchors

### DIFF
--- a/src/site/css/dart-style.css
+++ b/src/site/css/dart-style.css
@@ -22,7 +22,8 @@ a:hover {
 /* place link target below the header bar. The top padding should match the
 header height */
 .has-permalink:target,
-a[name]:target {
+a[name]:target,
+a[id]:target {
   padding-top: 65px;
 }
 

--- a/src/site/tools/editor/troubleshoot.html
+++ b/src/site/tools/editor/troubleshoot.html
@@ -41,7 +41,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 
 <section>
 
-  <h2><a name="download-dart-editor"></a>
+  <h2><a id="download-dart-editor"></a>
     Getting your system architecture </h2>
 
   <div class="linux">
@@ -74,7 +74,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 
 <section>
 
-  <h2><a name="launch-dart-editor"> Launching Dart Editor </h2>
+  <h2><a id="launch-dart-editor"> Launching Dart Editor </h2>
 
   <div class="windows">
     <p>
@@ -141,7 +141,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
         </li>
     </ul>
 
-    <h3><a name="security-preferences"></a> Unidentified developer</h3>
+    <h3><a id="security-preferences"></a> Unidentified developer</h3>
 
     <p>
     If you're running Mac OS 10.8 (Mountain Lion),
@@ -179,7 +179,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
     you can change the preference back to its previous setting.
     </p>
 
-    <h3><a name="corruption"></a> "DartEditor.app" is damaged (64-bit only)</h3>
+    <h3><a id="corruption"></a> "DartEditor.app" is damaged (64-bit only)</h3>
 
     <p>
     Sometimes when you try to launch a new, 64-bit build of Dart Editor,
@@ -197,7 +197,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
     32-bit version of Dart Editor</a>.
     </p>
 
-    <h3><a name="java-install"></a> Java installation failure</h3>
+    <h3><a id="java-install"></a> Java installation failure</h3>
 
     <p>
     When you try to run Dart Editor but don't have a Java SE 6 runtime,
@@ -207,7 +207,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
     <a href="http://support.apple.com/kb/DL1572">install Java yourself</a>.
     </p>
 
-    <h3><a name="avstartup"></a> Slow startup</h3>
+    <h3><a id="avstartup"></a> Slow startup</h3>
 
     <p>
     If you use Sophos Anti-Virus,
@@ -233,7 +233,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
         and click Open. </li>
     </ol>
 
-    <h3><a name="mac-32bit"></a> 32-bit Mac</h3>
+    <h3><a id="mac-32bit"></a> 32-bit Mac</h3>
 
     <p>
     If you're using one of the increasingly rare 32-bit Macs,
@@ -256,7 +256,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 
   </div> <!-- end of mac-only section -->
 
-  <h3><a name="runtime"></a> Specifying the Java runtime</h3>
+  <h3><a id="runtime"></a> Specifying the Java runtime</h3>
 
   <p>
   If necessary, you can specify the Java runtime that Dart Editor uses.
@@ -297,7 +297,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h3><a name="increasing-memory"></a> Increasing memory</h3>
+  <h3><a id="increasing-memory"></a> Increasing memory</h3>
 
   <p>
   When building larger Dart applications, Dart Editor needs more
@@ -308,7 +308,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
   and change it to <code>-Xmx2000m</code>, or larger if you have more RAM
   available.</p>
 
-  <h3><a name="java7-gc-changes"></a> Java 7 garbage collection changes</h3>
+  <h3><a id="java7-gc-changes"></a> Java 7 garbage collection changes</h3>
 
   <p>
   Java 7 sports different garbage collection (GC) behavior than Java 6.
@@ -319,7 +319,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="dart-editor-crashed"></a> Dart Editor crashed and now I cannot relaunch it</h2>
+  <h2><a id="dart-editor-crashed"></a> Dart Editor crashed and now I cannot relaunch it</h2>
 
   <p>
   In extremely rare cases, a Dart Editor crash will corrupt the workspace
@@ -337,7 +337,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="dartium"></a> Launching Dartium</h2>
+  <h2><a id="dartium"></a> Launching Dartium</h2>
 
   <p>
   By default,
@@ -373,7 +373,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 
 
 <section>
-  <h2><a name="eclipse"></a> Using Eclipse</h2>
+  <h2><a id="eclipse"></a> Using Eclipse</h2>
 
   <p>
   If Dart Editor and Eclipse
@@ -390,7 +390,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="pub-get-firewall"></a> Running "pub get" behind a proxy</h2>
+  <h2><a id="pub-get-firewall"></a> Running "pub get" behind a proxy</h2>
 
   <p>
   When using <code>pub get</code> behind a proxy,
@@ -442,7 +442,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="breakpoints"></a> Breakpoints not triggering</h2>
+  <h2><a id="breakpoints"></a> Breakpoints not triggering</h2>
 
   <p>
   If your breakpoints are not being triggered, or you are seeing
@@ -454,7 +454,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="clear"></a> Clearing all settings</h2>
+  <h2><a id="clear"></a> Clearing all settings</h2>
 
   <p>
   Dart Editor settings are in a platform-dependent directory,
@@ -492,7 +492,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </section>
 
 <section>
-  <h2><a name="generating-heap-dumps"></a>
+  <h2><a id="generating-heap-dumps"></a>
     Collecting performance diagnostics</h2>
 
   <p>
@@ -522,7 +522,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 
 <div class="windows">
   <section>
-    <h2><a name="network-storage-problems"></a> Network storage problems</h2>
+    <h2><a id="network-storage-problems"></a> Network storage problems</h2>
 
     <p>
     Under some circumstances, network storage can prevent Dart Editor
@@ -545,7 +545,7 @@ description: "Installing and running Dart Editor is easy. Except when it isn't."
 </div>
 
 <section>
-  <h2><a name="bugs"></a> Other known issues</h2>
+  <h2><a id="bugs"></a> Other known issues</h2>
 
   <div class="linux">
     <p>


### PR DESCRIPTION
This PR fixes [Dart bug 19457](https://code.google.com/p/dart/issues/detail?id=19457) by changing the anchors to the same style as articles and api anchors.

No content changes.
