### PR TITLE
point to github for doc issues

### DIFF
--- a/src/site/_includes/footer.html
+++ b/src/site/_includes/footer.html
@@ -25,6 +25,7 @@
             <li><a href="http://pub.dartlang.org/">Pub packages</a></li>
             <li><a href="/docs/synonyms/">Synonyms with other languages</a></li>
             <li><a href="http://code.google.com/p/dart/issues/list">Dart bugs and feature requests</a></li>
+            <li><a href="https://github.com/dart-lang/dartlang.org">www.dartlang.org repo</a></li>
           </ul>
         </div>
         <div class="col-md-2">

--- a/src/site/_includes/tutorial.html
+++ b/src/site/_includes/tutorial.html
@@ -42,7 +42,7 @@
       </div> <!-- end code-links -->
 
       <div id="tutorial-toc">
-        <a href="http://code.google.com/p/dart/issues/entry?template=Tutorial%20feedback"
+        <a href="https://github.com/dart-lang/dartlang.org/issues"
          target="_blank">
         <i class="glyphicon glyphicon-comment"> </i>
         Send feedback

--- a/src/site/_includes/tutorial_main_page.html
+++ b/src/site/_includes/tutorial_main_page.html
@@ -16,7 +16,7 @@
             <p style="font-size:xx-small">Version: 25 Mar 2014</p>
           </div>
           <div class="col-md-4">
-            <a href="https://code.google.com/p/dart/issues/entry?template=Documentation%20issue/feedback"
+            <a href="https://github.com/dart-lang/dartlang.org/issues"
                target="_blank">
             <i class="glyphicon glyphicon-comment"> </i>
             Send feedback

--- a/src/site/docs/tutorials/1-TUTPAGEboilerplate.markdown
+++ b/src/site/docs/tutorials/1-TUTPAGEboilerplate.markdown
@@ -33,7 +33,7 @@ This section provides links to sources on github.
 This is a draft under construction.
 Your kindly worded
 <a
- href="http://code.google.com/p/dart/issues/entry?template=Tutorial%20feedback"
+ href="https://github.com/dart-lang/dartlang.org/issues"
  target="_blank">
 comments and suggestions
 </a>


### PR DESCRIPTION
I added a footer link to the github repo, plus I grepped for doc-specific references to the old big repo and fixed them.

@sethladd could you review? This is staged at https://bugs-dot-dart-lang.appspot.com/.
