### PR TITLE
s/pygments/highlighter/ to be rid of Deprecation warnings in jekyll

### DIFF
--- a/src/site/_config.yml
+++ b/src/site/_config.yml
@@ -4,7 +4,7 @@ source: .
 destination: ../../build/static
 markdown: kramdown
 permalink: /news/:year/:month/:day/:title.html
-highlighter: false
+highlighter: null
 custom:
   downloads:
     dartarchive-be-url-prefix: "http://storage.googleapis.com/dart-archive/channels/be/raw"

--- a/src/site/events/2014/flight-school/index.html
+++ b/src/site/events/2014/flight-school/index.html
@@ -1,7 +1,3 @@
----
-layout: none
----
-
 <!DOCTYPE html>
 <html class="no-js" ng-app="dart" itemscope itemtype="http://schema.org/Thing">
 <head>


### PR DESCRIPTION
`make server` is generating the following output:

```
Configuration file: /Users/srawlins/code/dartlang.org/src/site/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'.
Please update your config file accordingly. The allowed values are 'rouge', 'pygments'
or null.
            Source: .
       Destination: ../../build/static
      Generating...
```

This PR addresses that deprecation warning.

**EDIT** also fix the flight school layout warning
