### PR TITLE
Add ICE Code Editor to the list of who uses Dart

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -12,6 +12,9 @@ If you build production software with Dart, and want
 to be included in this list, please open a
 [pull request](https://github.com/dart-lang/dartlang.org). Thanks!
 
+[ICE Code Editor](https://github.com/eee-c/ice-code-editor)
+: Real-time visualizations in a code editor, supporting the book “3D Game Programming for Kids.”
+
 [Security Monkey from Netflix](https://github.com/Netflix/security_monkey)
 : Security Monkey monitors policy changes and alerts on insecure configurations in an AWS account.
 


### PR DESCRIPTION
Feels weird putting this at the top of the list, but that seems to be the convention that others have been following.
