### PR TITLE
Fixing broken links

### DIFF
--- a/src/site/codelabs/polymer/index.markdown
+++ b/src/site/codelabs/polymer/index.markdown
@@ -1699,14 +1699,11 @@ on our [Samples page](/samples/).
 * Learn more about Dart from
 the [Dart tutorials](/tutorials/).
 
-* <a href="/dart-up-and-running/contents/ch02.html">
-A Tour of the Dart Language</a>
+* [A Tour of the Dart Language](/docs/dart-up-and-running/contents/ch02.html)
 shows you how to use each major Dart feature,
 from variables and operators to classes and libraries.
 
-* <a href="/dart-up-and-running/contents/ch03.html"
->
-A Tour of the Dart Libraries</a>
+* [A Tour of the Dart Libraries](/docs/dart-up-and-running/contents/ch03.html)
 shows you how to use the major features in Dart’s libraries.
 
 </div>

--- a/src/site/tools/pub/assets-and-transformers.markdown
+++ b/src/site/tools/pub/assets-and-transformers.markdown
@@ -92,7 +92,7 @@ dependencies:
 
 The following example configures the [dart2js](/tools/dart2js/)
 transformer, which is used by [`pub serve`](cmd/pub-serve.html),
-[`pub build`](cmd/pub-build.html) and [`pub run`](pcmd/pub-run.html),
+[`pub build`](cmd/pub-build.html) and [`pub run`](cmd/pub-run.html),
 to analyze the code:
 
 {% prettify yaml %}

--- a/src/site/tools/pub/package-layout.markdown
+++ b/src/site/tools/pub/package-layout.markdown
@@ -184,7 +184,7 @@ resolve. Instead, your entrypoints should go in the appropriate
 
 Dart scripts placed inside of the `bin` directory are public. Any package
 that depends on your package can run scripts from your package's `bin`
-directory using [`pub run`](cmd/pub-run). <em>Any</em> package can run scripts
+directory using [`pub run`](cmd/pub-run.html). <em>Any</em> package can run scripts
 from your package's bin directory using [`pub global`](cmd/pub-global.html).
 
 If you intend for your package to be depended on,


### PR DESCRIPTION
These should be the last broken links sitting around dartlang.org.
