### PR TITLE
Add Dev Channel information

### DIFF
--- a/src/site/js/dev-channel.js
+++ b/src/site/js/dev-channel.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+  $.getJSON(
+    "https://storage.googleapis.com/dart-archive/channels/dev/release/latest/VERSION",
+    function( data ) {
+        var date = data.date;
+        var revDate = date.substr(0,4) + "-" + date.substr(4,2) + "-" + date.substr(6,2);
+        $(".dev-channel").append($("<strong></strong>").text("version " +data.version))
+                         .append($("<span></span>").text(", built on " + revDate))
+                         .append($("<span></span>").text(", at revision " + data.revision));
+  });
+});

--- a/src/site/tools/download.markdown
+++ b/src/site/tools/download.markdown
@@ -3,6 +3,9 @@ layout: default
 title: "Download Dart"
 description: "The download bundles that support the Dart language."
 has-permalinks: false
+js:
+- url: /js/dev-channel.js
+  defer: true
 ---
 
 # Getting and Installing Dart Is Easy!
@@ -83,6 +86,8 @@ you can download the latest <strong>Dev Channel</strong> build of
  <a data-tool="editor" class="download-link" data-bits="64" data-os="macos" data-build="continuous" href="https://storage.googleapis.com/dart-archive/channels/dev/release/latest/editor/darteditor-macos-x64.zip">Dart Editor for
 Mac OS X</a>.
 </span>
+
+The latest Dev Channel release is <span class="dev-channel"></span>.
 </aside>
 
 Once the download is complete, unzip the bundle. Dart is installed!
@@ -175,6 +180,8 @@ You can also download the latest **Dev Channel** build of
 or
 <a href="https://storage.googleapis.com/dart-archive/channels/dev/release/latest/dartium/dartium-linux-ia32-release.zip">Dartium for Linux 32-bit</a>.
 </span>
+
+The latest Dev Channel release is <span class="dev-channel"></span>.
 </aside>
 
 ### Dart SDK for Debian and Ubuntu


### PR DESCRIPTION
This fixes #770. It's live at https://issue-770-dev-channel-revs-dot-dart-lang.appspot.com/tools/download.html in the **Early adopter** asides.

It's using https now, and JQuery's `text()` to prevent XSS.
