### PR TITLE
Add SHA-256 sum links

### DIFF
--- a/src/site/_includes/downloads/_dartium.html
+++ b/src/site/_includes/downloads/_dartium.html
@@ -7,6 +7,9 @@
     	DOWNLOAD DARTIUM (WINDOWS)
       </button>
     </a>
+    <a href="{{ site.custom.downloads.dartarchive-stable-url-prefix }}/latest/dartium/dartium-windows-ia32-release.zip.sha256sum">
+      (SHA-256)
+    </a>
   </span>
 
   <span class="macos">
@@ -16,6 +19,9 @@
     	DOWNLOAD DARTIUM (MAC)
       </button>
     </a>
+    <a href="{{ site.custom.downloads.dartarchive-stable-url-prefix }}/latest/dartium/dartium-macos-ia32-release.zip.sha256sum">
+      (SHA-256)
+    </a>
   </span>
 
   <span class="linux">
@@ -24,6 +30,9 @@
     	<i class="sprite-icon-download-btn"> </i>
     	DOWNLOAD DARTIUM (LINUX)
       </button>
+    </a>
+    <a href="{{ site.custom.downloads.dartarchive-stable-url-prefix }}/latest/dartium/dartium-linux-x64-release.zip.sha256sum">
+      (SHA-256)
     </a>
   </span>
   

--- a/src/site/_includes/downloads/_sdk-button.html
+++ b/src/site/_includes/downloads/_sdk-button.html
@@ -9,3 +9,8 @@
   Download Dart SDK ({{ include.name }})
 </button>
 </a>
+
+<a href="{{ site.custom.downloads.dartarchive-stable-url-prefix }}/latest/sdk/dartsdk-{{ sdk.os }}-{{ include.arch }}-release.{{ sdk.ext }}.sha256sum">
+  (SHA-256)
+</a>
+<br />


### PR DESCRIPTION
Fixes #932 

The bundles don't have SHA-256 sums. Only MD5. So I've opted to not include them. I could stage this, but I think I have to many staged apps up for PRs right now.
