### PR TITLE
Fixed typos in example code

### DIFF
--- a/src/site/articles/native-extensions-for-standalone-dart-vm/index.markdown
+++ b/src/site/articles/native-extensions-for-standalone-dart-vm/index.markdown
@@ -225,7 +225,7 @@ DART_EXPORT Dart_Handle sample_extension_Init(Dart_Handle parent_library) {
   if (Dart_IsError(parent_library)) return parent_library;
 
   Dart_Handle result_code =
-      Dart_SetNativeResolver(parent_library, ResolveName);
+      Dart_SetNativeResolver(parent_library, ResolveName, NULL);
   if (Dart_IsError(result_code)) return result_code;
 
   return Dart_Null();
@@ -262,7 +262,7 @@ void SystemSrand(Dart_NativeArguments arguments) {
 
 Dart_NativeFunction ResolveName(Dart_Handle name, int argc, bool* auto_setup_scope) {
   // If we fail, we return NULL, and Dart throws an exception.
-  if (!Dart_IsString8(name)) return NULL;
+  if (!Dart_IsString(name)) return NULL;
   Dart_NativeFunction result = NULL;
   const char* cname;
   HandleError(Dart_StringToCString(name, &cname));


### PR DESCRIPTION
Fixed typo in Dart_IsString() call;
Fixed parameter call to Dart_SetNativeResolver();
