### PR TITLE
Deleted vestigial reference to removed HTML Interactive unit test reportor

### DIFF
--- a/src/site/articles/dart-unit-tests/index.markdown
+++ b/src/site/articles/dart-unit-tests/index.markdown
@@ -1059,11 +1059,6 @@ These are:
   but provides a richer layout;
   call `useHtmlEnhancedConfiguration()` to use this,
   and import `html_enhanced_config.dart`
-* `HtmlInteractiveConfiguration`,
-  which provides a rich in-browser layout
-  with the ability to enable/disable tests and rerun tests;
-  call `useHtmlInteractiveConfiguration()` to use this,
-  and import `html_enhanced_config.dart`
 
 For running tests in a continuous integration environment,
 the default or VM configurations are most useful.


### PR DESCRIPTION
The HTML Interactive unit test reporter has been removed.  I've deleted the reference to it from the unit test docs.
