### PR TITLE
make server: Don't fire the browser until jekyll is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 CURRENT_BRANCH=$(shell git branch --no-color | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/')
 LAST_COMMIT=$(shell git log -n 1 --pretty=format:"%H")
 PWD=$(shell pwd)
+LOCAL=http://localhost:8081/
 XDGOPEN=$(shell type xdg-open 2>/dev/null)
+ifeq ($(XDGOPEN),)
+OPEN=open $(LOCAL)
+else
+OPEN=xdg-open $(LOCAL)
+endif
 
 clean:
 	rm -rf ./build
@@ -23,11 +29,7 @@ deploy: build
 	@echo "Visit https://$(CURRENT_BRANCH)-dot-dart-lang.appspot.com"
 
 server:
-ifeq ($(XDGOPEN),)
-	@open "http://localhost:8081/" &
-else
-	@xdg-open "http://localhost:8081/" &
-endif
+	ruby -e 'sleep 3; 1.upto(30) { break if system("curl -I -s $(LOCAL)"); print "."; sleep 1 }; exec "$(OPEN)"' &
 	cd ./src/site && bundle exec jekyll serve -w --port=8081 --trace
 
 optimize:


### PR DESCRIPTION
Currently when you `make server`, your browser immediately opens to a dead page, and you must ALT+TAB back to the terminal to know when you can refresh. This PR fixes that:

```
ruby -e 'sleep 3; 1.upto(30) { break if system("curl -I -s $(LOCAL)"); print "."; sleep 1 }; exec "$(OPEN)"'
                  ^            ^                                     ^                     ^ ^             ^
                  |            '- -  break when the site is ready - -'                     | '- open site -'
                  |                                                                        |
                  '- - - - - - - - - - -   loop for up to 30 seconds  - - - - - - - - - - -'
```
