### PR TITLE
Fixing download_archive packages

### DIFF
--- a/src/site/tools/download_archive/packages/browser
+++ b/src/site/tools/download_archive/packages/browser
@@ -1,1 +1,0 @@
-/Users/srawlins/.pub-cache/hosted/pub.dartlang.org/browser-0.10.0+2/lib

--- a/src/site/tools/download_archive/packages/browser/dart.js
+++ b/src/site/tools/download_archive/packages/browser/dart.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+(function() {
+// Bootstrap support for Dart scripts on the page as this script.
+if (navigator.userAgent.indexOf('(Dart)') === -1) {
+  // TODO:
+  // - Support in-browser compilation.
+  // - Handle inline Dart scripts.
+
+  // Fall back to compiled JS. Run through all the scripts and
+  // replace them if they have a type that indicate that they source
+  // in Dart code (type="application/dart").
+  var scripts = document.getElementsByTagName("script");
+  var length = scripts.length;
+  for (var i = 0; i < length; ++i) {
+    if (scripts[i].type == "application/dart") {
+      // Remap foo.dart to foo.dart.js.
+      if (scripts[i].src && scripts[i].src != '') {
+        var script = document.createElement('script');
+        script.src = scripts[i].src.replace(/\.dart(?=\?|$)/, '.dart.js');
+        var parent = scripts[i].parentNode;
+        // TODO(vsm): Find a solution for issue 8455 that works with more
+        // than one script.
+        document.currentScript = script;
+        parent.replaceChild(script, scripts[i]);
+      }
+    }
+  }
+}
+})();

--- a/src/site/tools/download_archive/packages/browser/interop.js
+++ b/src/site/tools/download_archive/packages/browser/interop.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO(jmesserly): remove this script after a deprecation period.
+if (typeof console == "object" && typeof console.warn == "function") {
+  console.warn('<script src="packages/browser/interop.js"> is no longer ' +
+      'needed for dart:js. See http://pub.dartlang.org/packages/browser.');
+}


### PR DESCRIPTION
This should fix the download_archive packages, which were ignored before.

I added real browser files (they were symlinked before...), so this looks similar to `src/site/docs/tutorials/remove-elements/examples/todo_with_delete/packages/`
