### PR TITLE
Adding SonarDesign and Lumo to who-uses-dart.html

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -132,3 +132,9 @@ Google internal tool for marketing
 
 [Google Shopping Express](https://www.google.com/shopping/express/)
 : An enterprise tool to manage drivers/couriers, built with AngularDart.
+
+[SonarDesign] (http://www.sonardesign.com)
+: A high-performance, HTML5 web app authoring and distribution platform built on and made for the modern web.
+
+[Lumo] (http://lumo.sonardesign.com)
+: An online presentation service that allows you to create, present, and share presentations on any device.


### PR DESCRIPTION
SonarDesign is a Dart shop that has shipped 2 separate production Dart products.

I have added a link to the main site, as well as to our Lumo product, which is in active development.
