### PR TITLE
Removing space that breaks sonardesign + lumo links

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -133,10 +133,10 @@ Google internal tool for marketing
 [Google Shopping Express](https://www.google.com/shopping/express/)
 : An enterprise tool to manage drivers/couriers, built with AngularDart.
 
-[SonarDesign] (http://www.sonardesign.com)
+[SonarDesign](http://www.sonardesign.com)
 : A high-performance, HTML5 web app authoring and distribution platform built on and made for the modern web.
 
-[Lumo] (http://lumo.sonardesign.com)
+[Lumo](http://lumo.sonardesign.com)
 : An online presentation service that allows you to create, present, and share presentations on any device.
 
 [Children of Ur](http://www.childrenofur.com/)


### PR DESCRIPTION
This rendered correctly on GitHub on my fork, but now that you've pushed my links live I see that they are broken. I think this change should fix them.
