### PR TITLE
Adding API documentation downloads to the archive

### DIFF
--- a/src/site/_includes/downloads/_archives_table.html
+++ b/src/site/_includes/downloads/_archives_table.html
@@ -37,28 +37,6 @@
     {% endif %}
     <td>Windows</td>
     <td>64-width</td>
-    <td>Dart SDK | Dartium | Dart Editor</td>
-  </tr>
-</table><br />
-
-<p>The historical Dart API Documentation are available as zipped JSON data. The
-   documentation can be viewed with the <a href="https://github.com/dart-lang/dartdoc-viewer">dartdoc-viewer</a>.
-</p>
-
-<table id="{{include.channel}}-api" class="downloads">
-  <tr>
-    <th style="min-width: 200px;">Version</th>
-    <th style="min-width: 250px;">API Documentation</th>
-  </tr>
-  <tr class="template">
-    <td colspan="2" style="height: 100px;"><img src="/imgs/spinner.gif" /></td>
-  </tr>
-  <tr style="visibility: hidden !important;" class="template">
-    {% if include.channel == 'stable' %}
-    <td>0.0.0 (rev 00000)</td>
-    {% else %}
-    <td>0.0.0-dev.0.0 (rev 00000)</td>
-    {% endif %}
     <td>JSON-formatted API Documentation</td>
   </tr>
 </table>

--- a/src/site/tools/download_archive/index.markdown
+++ b/src/site/tools/download_archive/index.markdown
@@ -20,12 +20,18 @@ historical downloads.
 
 ## Stable channel
 
-The stable channel includes historical downloads of previous stable Dart releases.
+You can download archived versions of Stable channel downloads of Dart tools
+and API reference documentation. To view the API documentation, unzip the
+archive and then view the JSON files using
+[dartdoc-viewer](https://github.com/dart-lang/dartdoc-viewer).
 
 {% include downloads/_archives_table.html channel="stable" %}
 
 ## Dev channel
 
-The dev channel includes historical downloads of unstable preview builds of Dart.
+You can download archived versions of Dev channel downloads of Dart tools
+and API reference documentation. To view the API documentation, unzip the
+archive and then view the JSON files using
+[dartdoc-viewer](https://github.com/dart-lang/dartdoc-viewer).
 
 {% include downloads/_archives_table.html channel="dev" %}

--- a/src/site/tools/download_archive/out/web/download_archive.dart.js
+++ b/src/site/tools/download_archive/out/web/download_archive.dart.js
@@ -2279,7 +2279,7 @@ Dy:{
 $0:function(){this.d.In(this.c)}},
 MO:{
 "^":"a;"},
-Uf:{
+nP:{
 "^":"a;"},
 fI:{
 "^":"a;"},
@@ -3917,12 +3917,11 @@ z=J.Vs(J.UQ(J.IT($.cB().t(0,a)),0)).dA.getAttribute("value")
 y=J.Vs(J.UQ(J.IT($.P9().t(0,a)),0)).dA.getAttribute("value")
 x=z==="all"
 if(x&&y==="all")W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).Rz(0,"hidden")
-else{w=!x?"tr"+("[data-version=\""+H.d(z)+"\"]"):"tr"
+else{W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
+w=!x?"tr"+("[data-version=\""+H.d(z)+"\"]"):"tr"
+W.or(W.vD($.RQ().t(0,a).querySelectorAll(w+"[data-os=\"api\"]"),null).xa).Rz(0,"hidden")
 if(y!=="all")w+="[data-os=\""+H.d(y)+"\"]"
-W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
-W.or(W.vD($.RQ().t(0,a).querySelectorAll(w),null).xa).Rz(0,"hidden")}if(x)W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version]"),null).xa).Rz(0,"hidden")
-else{W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
-W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version=\""+H.d(z)+"\"]"),null).xa).Rz(0,"hidden")}},
+W.or(W.vD($.RQ().t(0,a).querySelectorAll(w),null).xa).Rz(0,"hidden")}},
 EK:function(a,b){var z,y
 z=H.HD(J.UQ(C.xr.kV(b),"prefixes"),"$iszM",[P.qU],"$aszM")
 y=J.w1(z)
@@ -3935,15 +3934,18 @@ z.textContent=y.t(b,"version")
 z.setAttribute("value",y.t(b,"version"))
 J.OG($.cB().t(0,a)).h(0,z)
 C.xO.aN(0,new E.b9(a,b))
-x=J.vd($.nP().t(0,a))
+x=J.vd($.RQ().t(0,a))
 x.toString
 x.setAttribute("data-version",y.t(b,"version"))
+x.setAttribute("data-os","api")
 w=document.createElement("span",null)
 w.textContent="  (rev "+H.d(y.t(b,"revision"))+")"
 J.pP(w).h(0,"muted")
 v=J.ae(x)
 v.textContent=y.t(b,"version")
 v.appendChild(w)
+x.insertCell(-1).textContent="---"
+x.insertCell(-1).textContent="---"
 u=x.insertCell(-1)
 u.toString
 new W.I4(u).h(0,"archives")
@@ -3953,9 +3955,7 @@ y.textContent="JSON-formatted API Documentation"
 y.setAttribute("href",t)
 u.appendChild(y)
 s=W.vD($.RQ().t(0,a).querySelectorAll(".template"),null)
-s.aN(s,new E.wA())
-s=W.vD($.nP().t(0,a).querySelectorAll(".template"),null)
-s.aN(s,new E.zv())},
+s.aN(s,new E.wA())},
 em:{
 "^":"Tp:10;",
 $1:function(a){E.EK("stable",a)}},
@@ -4047,9 +4047,6 @@ z.setAttribute("href",x+".sha256sum")
 J.pP(z).h(0,"sha")
 w.appendChild(z)}w.appendChild(W.r3("br",null))}}},
 wA:{
-"^":"Tp:10;",
-$1:function(a){J.Mp(a)}},
-zv:{
 "^":"Tp:10;",
 $1:function(a){J.Mp(a)}}},1],["","",,P,{
 "^":"",
@@ -4175,8 +4172,8 @@ y.$isa=z
 y=P.fR
 y.$isfR=z
 y.$isa=z
-y=P.Uf
-y.$isUf=z
+y=P.nP
+y.$isnP=z
 y.$isa=z
 y=P.b8
 y.$isb8=z
@@ -4484,7 +4481,6 @@ I.$lazy($,"undefinedLiteralPropertyPattern","A7","ko",function(){return H.cM(fun
 I.$lazy($,"scheduleImmediateClosure","lI","ej",function(){return P.xg()})
 I.$lazy($,"_toStringVisiting","nM","Ex",function(){return[]})
 I.$lazy($,"tables","aU","RQ",function(){return P.EF(["stable",document.querySelector("#stable"),"dev",document.querySelector("#dev")],null,null)})
-I.$lazy($,"apiTables","MR","nP",function(){return P.EF(["stable",document.querySelector("#stable-api"),"dev",document.querySelector("#dev-api")],null,null)})
 I.$lazy($,"versionSelectors","Jf","cB",function(){return P.EF(["stable",document.querySelector("#stable-versions"),"dev",document.querySelector("#dev-versions")],null,null)})
 I.$lazy($,"osSelectors","vw","P9",function(){return P.EF(["stable",document.querySelector("#stable-os"),"dev",document.querySelector("#dev-os")],null,null)})
 

--- a/src/site/tools/download_archive/out/web/download_archive.dart.precompiled.js
+++ b/src/site/tools/download_archive/out/web/download_archive.dart.precompiled.js
@@ -2279,7 +2279,7 @@ Dy:{
 $0:function(){this.d.In(this.c)}},
 MO:{
 "^":"a;"},
-Uf:{
+nP:{
 "^":"a;"},
 fI:{
 "^":"a;"},
@@ -3917,12 +3917,11 @@ z=J.Vs(J.UQ(J.IT($.cB().t(0,a)),0)).dA.getAttribute("value")
 y=J.Vs(J.UQ(J.IT($.P9().t(0,a)),0)).dA.getAttribute("value")
 x=z==="all"
 if(x&&y==="all")W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).Rz(0,"hidden")
-else{w=!x?"tr"+("[data-version=\""+H.d(z)+"\"]"):"tr"
+else{W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
+w=!x?"tr"+("[data-version=\""+H.d(z)+"\"]"):"tr"
+W.or(W.vD($.RQ().t(0,a).querySelectorAll(w+"[data-os=\"api\"]"),null).xa).Rz(0,"hidden")
 if(y!=="all")w+="[data-os=\""+H.d(y)+"\"]"
-W.or(W.vD($.RQ().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
-W.or(W.vD($.RQ().t(0,a).querySelectorAll(w),null).xa).Rz(0,"hidden")}if(x)W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version]"),null).xa).Rz(0,"hidden")
-else{W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version]"),null).xa).h(0,"hidden")
-W.or(W.vD($.nP().t(0,a).querySelectorAll("tr[data-version=\""+H.d(z)+"\"]"),null).xa).Rz(0,"hidden")}},
+W.or(W.vD($.RQ().t(0,a).querySelectorAll(w),null).xa).Rz(0,"hidden")}},
 EK:function(a,b){var z,y
 z=H.HD(J.UQ(C.xr.kV(b),"prefixes"),"$iszM",[P.qU],"$aszM")
 y=J.w1(z)
@@ -3935,15 +3934,18 @@ z.textContent=y.t(b,"version")
 z.setAttribute("value",y.t(b,"version"))
 J.OG($.cB().t(0,a)).h(0,z)
 C.xO.aN(0,new E.b9(a,b))
-x=J.vd($.nP().t(0,a))
+x=J.vd($.RQ().t(0,a))
 x.toString
 x.setAttribute("data-version",y.t(b,"version"))
+x.setAttribute("data-os","api")
 w=document.createElement("span",null)
 w.textContent="  (rev "+H.d(y.t(b,"revision"))+")"
 J.pP(w).h(0,"muted")
 v=J.ae(x)
 v.textContent=y.t(b,"version")
 v.appendChild(w)
+x.insertCell(-1).textContent="---"
+x.insertCell(-1).textContent="---"
 u=x.insertCell(-1)
 u.toString
 new W.I4(u).h(0,"archives")
@@ -3953,9 +3955,7 @@ y.textContent="JSON-formatted API Documentation"
 y.setAttribute("href",t)
 u.appendChild(y)
 s=W.vD($.RQ().t(0,a).querySelectorAll(".template"),null)
-s.aN(s,new E.wA())
-s=W.vD($.nP().t(0,a).querySelectorAll(".template"),null)
-s.aN(s,new E.zv())},
+s.aN(s,new E.wA())},
 em:{
 "^":"Tp:10;",
 $1:function(a){E.EK("stable",a)}},
@@ -4047,9 +4047,6 @@ z.setAttribute("href",x+".sha256sum")
 J.pP(z).h(0,"sha")
 w.appendChild(z)}w.appendChild(W.r3("br",null))}}},
 wA:{
-"^":"Tp:10;",
-$1:function(a){J.Mp(a)}},
-zv:{
 "^":"Tp:10;",
 $1:function(a){J.Mp(a)}}},1],["","",,P,{
 "^":"",
@@ -4175,8 +4172,8 @@ y.$isa=z
 y=P.fR
 y.$isfR=z
 y.$isa=z
-y=P.Uf
-y.$isUf=z
+y=P.nP
+y.$isnP=z
 y.$isa=z
 y=P.b8
 y.$isb8=z
@@ -4484,7 +4481,6 @@ I.$lazy($,"undefinedLiteralPropertyPattern","A7","ko",function(){return H.cM(fun
 I.$lazy($,"scheduleImmediateClosure","lI","ej",function(){return P.xg()})
 I.$lazy($,"_toStringVisiting","nM","Ex",function(){return[]})
 I.$lazy($,"tables","aU","RQ",function(){return P.EF(["stable",document.querySelector("#stable"),"dev",document.querySelector("#dev")],null,null)})
-I.$lazy($,"apiTables","MR","nP",function(){return P.EF(["stable",document.querySelector("#stable-api"),"dev",document.querySelector("#dev-api")],null,null)})
 I.$lazy($,"versionSelectors","Jf","cB",function(){return P.EF(["stable",document.querySelector("#stable-versions"),"dev",document.querySelector("#dev-versions")],null,null)})
 I.$lazy($,"osSelectors","vw","P9",function(){return P.EF(["stable",document.querySelector("#stable-os"),"dev",document.querySelector("#dev-os")],null,null)})
 
@@ -6736,11 +6732,11 @@ if(!"name" in MO)MO.name="MO"
 $desc=$collectedClasses.MO
 if($desc instanceof Array)$desc=$desc[1]
 MO.prototype=$desc
-function Uf(){}Uf.builtin$cls="Uf"
-if(!"name" in Uf)Uf.name="Uf"
-$desc=$collectedClasses.Uf
+function nP(){}nP.builtin$cls="nP"
+if(!"name" in nP)nP.name="nP"
+$desc=$collectedClasses.nP
 if($desc instanceof Array)$desc=$desc[1]
-Uf.prototype=$desc
+nP.prototype=$desc
 function fI(){}fI.builtin$cls="fI"
 if(!"name" in fI)fI.name="fI"
 $desc=$collectedClasses.fI
@@ -7465,11 +7461,6 @@ if(!"name" in wA)wA.name="wA"
 $desc=$collectedClasses.wA
 if($desc instanceof Array)$desc=$desc[1]
 wA.prototype=$desc
-function zv(){}zv.builtin$cls="zv"
-if(!"name" in zv)zv.name="zv"
-$desc=$collectedClasses.zv
-if($desc instanceof Array)$desc=$desc[1]
-zv.prototype=$desc
 function As(){}As.builtin$cls="As"
 if(!"name" in As)As.name="As"
 $desc=$collectedClasses.As
@@ -7496,4 +7487,4 @@ if(!"name" in GS)GS.name="GS"
 $desc=$collectedClasses.GS
 if($desc instanceof Array)$desc=$desc[1]
 GS.prototype=$desc
-return[qE,Gh,rK,fY,Mr,lJ,ct,nB,i3,it,Yf,IF,n6,Ny,nx,QQ,MA,y4,d7,Um,DG,HA,vH,hh,Em,NW,rV,K4,QF,hs,cm,Nh,cv,Fs,Ty,ea,D0,as,Aa,u5,Yu,iG,jP,FO,xf,xn,Vb,QH,ST,X2,zU,Vi,tb,pA,Mi,KD,Ln,HL,In,wP,eP,AL,Og,M6,El,mC,SV,aB,fJ,Ih,D8,Vh,rC,ZY,cx,Ee,Qb,PG,Hw,xI,Aj,oU,eY,KV,BH,KY,G7,l9,Ql,wL,bP,mX,SN,me,ni,rR,qj,nC,KR,ew,fs,M9,A6,MC,iQ,j2,Ea,lp,kd,I0,yN,Cp,ua,zD,Ul,KK,ii,fq,h4,qk,GI,Tb,Iv,BT,yY,kJ,FB,xV,FH,y6,RH,YK,Z2,w6,BR,r4,aG,fA,K5,Xg,UM,YC,hq,r0,yp,c1,Mq,Nf,Nc,rj,rh,Zv,nA,yK,Y0,ZJ,mU,ph,Bg,JY,Pq,kx,nV,Zc,ui,D6,DQ,Sm,xL,QU,es,jw,lv,pf,NV,W1,zo,wf,TU,ih,Nd,zp,Xu,lu,tk,US,oB,Ah,yu,MI,oa,bM,eW,Qy,ju,OE,f1,BA,d0,tp,rE,CC,PQ,uz,Yd,p8,AD,Gr,Gq,GH,To,NJ,qI,jf,rQ,Lx,d5,hy,r8,aS,CG,UN,jk,Rk,Eo,YS,o4,ZD,vt,wD,BD,vR,Ja,zI,hW,LQ,yR,HP,fa,l4,Et,QS,Pi,qO,xt,cO,P0,xl,Xr,Sl,Qm,ET,V6,eo,Gv,kn,YE,Ue,iC,is,Q,P,im,VA,O,PK,JO,O2,aX,NY,cC,RA,IY,JH,jl,Vg,Iy,JM,Ua,ns,yo,Bj,NO,II,fP,X1,HU,oo,OW,Tf,iY,yH,FA,Av,ku,ys,LP,hY,XR,FD,Zr,W0,az,vV,Am,XO,dr,TL,KX,uZ,OQ,Tp,Bp,v,Pe,Eq,lb,tD,hJ,cu,dC,wN,VX,tQ,aL,bX,a7,i1,xy,MH,A8,U5,SO,TN,Lj,Qr,IW,th,ha,C6,Ca,O6,b8,VN,ff,Pf,Zf,vs,da,pV,U7,rH,cX,ZL,rq,RW,YP,jZ,FZ,OM,qh,Sd,jv,bi,YJ,lz,Rl,Jb,M4,B5,PI,VV,Dy,MO,Uf,fI,dR,uR,QX,m0,pK,R8,hj,MK,pQ,FG,k6,oi,fG,EQ,YB,a1,db,i5,N6,b6,tj,zQ,Yp,u3,mW,LU,E9,lD,LG,Sw,o0,Ma,Vj,uw,A5,Uk,zF,by,QM,CL,a2,fR,CP,a6,P7,DW,Ge,LK,AT,bJ,ub,ds,lj,UV,VS,t7,HG,aE,kM,EH,KN,QV,An,zM,Z0,c8,lf,a,Od,mE,qU,Rn,wv,VG,DY,wz,B1,zL,ec,Kx,hH,bU,e7,dx,x5,xv,rp,hm,rl,tJ,i7,nF,FK,Si,vf,Fc,hD,I4,Fk,RO,Cq,xC,Pb,W9,O7,IU,b0,DV,Ob,GV,em,Lb,QA,Cv,ed,wa,Mx,fv,Tl,N9,nS,y7,b9,Ne,hf,wA,zv,As,GE,D7,hT,GS]}
+return[qE,Gh,rK,fY,Mr,lJ,ct,nB,i3,it,Yf,IF,n6,Ny,nx,QQ,MA,y4,d7,Um,DG,HA,vH,hh,Em,NW,rV,K4,QF,hs,cm,Nh,cv,Fs,Ty,ea,D0,as,Aa,u5,Yu,iG,jP,FO,xf,xn,Vb,QH,ST,X2,zU,Vi,tb,pA,Mi,KD,Ln,HL,In,wP,eP,AL,Og,M6,El,mC,SV,aB,fJ,Ih,D8,Vh,rC,ZY,cx,Ee,Qb,PG,Hw,xI,Aj,oU,eY,KV,BH,KY,G7,l9,Ql,wL,bP,mX,SN,me,ni,rR,qj,nC,KR,ew,fs,M9,A6,MC,iQ,j2,Ea,lp,kd,I0,yN,Cp,ua,zD,Ul,KK,ii,fq,h4,qk,GI,Tb,Iv,BT,yY,kJ,FB,xV,FH,y6,RH,YK,Z2,w6,BR,r4,aG,fA,K5,Xg,UM,YC,hq,r0,yp,c1,Mq,Nf,Nc,rj,rh,Zv,nA,yK,Y0,ZJ,mU,ph,Bg,JY,Pq,kx,nV,Zc,ui,D6,DQ,Sm,xL,QU,es,jw,lv,pf,NV,W1,zo,wf,TU,ih,Nd,zp,Xu,lu,tk,US,oB,Ah,yu,MI,oa,bM,eW,Qy,ju,OE,f1,BA,d0,tp,rE,CC,PQ,uz,Yd,p8,AD,Gr,Gq,GH,To,NJ,qI,jf,rQ,Lx,d5,hy,r8,aS,CG,UN,jk,Rk,Eo,YS,o4,ZD,vt,wD,BD,vR,Ja,zI,hW,LQ,yR,HP,fa,l4,Et,QS,Pi,qO,xt,cO,P0,xl,Xr,Sl,Qm,ET,V6,eo,Gv,kn,YE,Ue,iC,is,Q,P,im,VA,O,PK,JO,O2,aX,NY,cC,RA,IY,JH,jl,Vg,Iy,JM,Ua,ns,yo,Bj,NO,II,fP,X1,HU,oo,OW,Tf,iY,yH,FA,Av,ku,ys,LP,hY,XR,FD,Zr,W0,az,vV,Am,XO,dr,TL,KX,uZ,OQ,Tp,Bp,v,Pe,Eq,lb,tD,hJ,cu,dC,wN,VX,tQ,aL,bX,a7,i1,xy,MH,A8,U5,SO,TN,Lj,Qr,IW,th,ha,C6,Ca,O6,b8,VN,ff,Pf,Zf,vs,da,pV,U7,rH,cX,ZL,rq,RW,YP,jZ,FZ,OM,qh,Sd,jv,bi,YJ,lz,Rl,Jb,M4,B5,PI,VV,Dy,MO,nP,fI,dR,uR,QX,m0,pK,R8,hj,MK,pQ,FG,k6,oi,fG,EQ,YB,a1,db,i5,N6,b6,tj,zQ,Yp,u3,mW,LU,E9,lD,LG,Sw,o0,Ma,Vj,uw,A5,Uk,zF,by,QM,CL,a2,fR,CP,a6,P7,DW,Ge,LK,AT,bJ,ub,ds,lj,UV,VS,t7,HG,aE,kM,EH,KN,QV,An,zM,Z0,c8,lf,a,Od,mE,qU,Rn,wv,VG,DY,wz,B1,zL,ec,Kx,hH,bU,e7,dx,x5,xv,rp,hm,rl,tJ,i7,nF,FK,Si,vf,Fc,hD,I4,Fk,RO,Cq,xC,Pb,W9,O7,IU,b0,DV,Ob,GV,em,Lb,QA,Cv,ed,wa,Mx,fv,Tl,N9,nS,y7,b9,Ne,hf,wA,As,GE,D7,hT,GS]}

--- a/src/site/tools/download_archive/web/download_archive.dart
+++ b/src/site/tools/download_archive/web/download_archive.dart
@@ -5,7 +5,6 @@ import 'dart:html';
 const String storageApiBase = "https://www.googleapis.com/storage/v1/b/dart-archive/o";
 const String storageBase = "https://storage.googleapis.com/dart-archive";
 Map<String,TableElement> tables = { 'stable': querySelector("#stable"), 'dev': querySelector('#dev') };
-Map<String,TableElement> apiTables = { 'stable': querySelector("#stable-api"), 'dev': querySelector('#dev-api') };
 Map<String,SelectElement> versionSelectors = {
     'stable': querySelector('#stable-versions'),
     'dev': querySelector('#dev-versions')
@@ -33,18 +32,12 @@ void filterTable(String channel, Event event) {
   if (selectedVersion == 'all' && selectedOs == 'all') {
     tables[channel].querySelectorAll('tr[data-version]').classes.remove('hidden');
   } else {
+    tables[channel].querySelectorAll('tr[data-version]').classes.add('hidden');
     String selector = 'tr';
     if (selectedVersion != 'all') { selector += '[data-version="$selectedVersion"]'; }
+    tables[channel].querySelectorAll(selector+'[data-os="api"]').classes.remove('hidden');
     if (selectedOs != 'all') { selector += '[data-os="$selectedOs"]'; }
-    tables[channel].querySelectorAll('tr[data-version]').classes.add('hidden');
     tables[channel].querySelectorAll(selector).classes.remove('hidden');
-  }
-
-  if (selectedVersion == 'all') {
-    apiTables[channel].querySelectorAll('tr[data-version]').classes.remove('hidden');
-  } else {
-    apiTables[channel].querySelectorAll('tr[data-version]').classes.add('hidden');
-    apiTables[channel].querySelectorAll('tr[data-version="$selectedVersion"]').classes.remove('hidden');
   }
 }
 
@@ -135,13 +128,16 @@ void addVersion(String channel, Map<String,String> version) {
     });
   });
 
-  TableRowElement row = apiTables[channel].addRow()
-      ..attributes['data-version'] = version['version'];
+  TableRowElement row = tables[channel].addRow()
+      ..attributes['data-version'] = version['version']
+      ..attributes['data-os'] = 'api';
   SpanElement rev = new SpanElement()
       ..text = '  (rev ${version['revision']})'
       ..classes.add('muted');
   row.addCell()..text = version['version']
       ..append(rev);
+  row.addCell()..text = '---';
+  row.addCell()..text = '---';
   TableCellElement c = row.addCell()
       ..classes.add('archives');
   String uri = '$storageBase/channels/$channel/release/${version['revision']}/' +
@@ -151,7 +147,5 @@ void addVersion(String channel, Map<String,String> version) {
       ..attributes['href']= uri);
 
   List<Element> templateRows = tables[channel].querySelectorAll('.template');
-  if (templateRows != null) { templateRows.forEach((row) { row.remove(); }); }
-  templateRows = apiTables[channel].querySelectorAll('.template');
   if (templateRows != null) { templateRows.forEach((row) { row.remove(); }); }
 }


### PR DESCRIPTION
Fixes #933 

Provides download links for the archived API docs. The links link to the zip file, which contains a directory of JSON files. This is currently the only format which we provide the API documentation.

The [dartdoc-viewer](https://github.com/dart-lang/dartdoc-viewer) README shows how these can be viewed and served.

This is staged at https://issue-933-api-downloads-dot-dart-lang.appspot.com/tools/download_archive/

@sethladd @kwalrath @Sfshaza let me know what you think.
