### PR TITLE
update dcap and dgrep urls

### DIFF
--- a/src/site/docs/serverguide.markdown
+++ b/src/site/docs/serverguide.markdown
@@ -54,8 +54,8 @@ and illustrate a variety of APIs specific to command-line apps and servers.
 
 ### Basic command-line apps
 
-* [dcat](https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dcat/README.md)
-* [dgrep](https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dgrep/README.md)
+* [dcat](https://github.com/dart-lang/sample-dcat/blob/master/README.md)
+* [dgrep](https://github.com/dart-lang/sample-dgrep/blob/master/README.md)
 </div>
 <div class="col-md-7" markdown="1">
 

--- a/src/site/samples/samples.yaml
+++ b/src/site/samples/samples.yaml
@@ -77,13 +77,13 @@ col1:
     examples:
       -
         title: Searching files for content
-        explanation_url: https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dgrep/README.md
-        source_url: https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dgrep
+        explanation_url: https://github.com/dart-lang/sample-dgrep/blob/master/README.md
+        source_url: https://github.com/dart-lang/sample-dgrep/
         description: A short app that shows how to work with file and directories asynchronously.
       -
         title: Concatenating files
-        explanation_url: https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dcat/README.md
-        source_url: https://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/samples/dcat
+        explanation_url: https://github.com/dart-lang/sample-dcat/blob/master/README.md
+        source_url: https://github.com/dart-lang/sample-dcat/
         description: Use streams to read files and process I/O.
       -
         title: A search app using HttpServer and WebSockets


### PR DESCRIPTION
I started moving these examples to github. This updates the URL from the dartlang.org site.

@sethladd @kwalrath 
