### PR TITLE
Responsivize new downloads page

### DIFF
--- a/src/site/css/dart-style.css
+++ b/src/site/css/dart-style.css
@@ -1660,3 +1660,29 @@ dd{
 .thinborder {
     border:1px solid #021a40;
 }
+
+/*
+ * Because Bootstrap doesn't have a responsive button group yet.
+ */
+@media (max-width: 768px) {
+  .btn-group-responsive .btn-group {
+    display: block;
+    width: 100%;
+  }
+
+  .btn-group-responsive .btn-group + .btn-group {
+    margin-left: 0;
+  }
+
+  .btn-group-responsive > .btn-group:first-child:not(:last-child) > .btn {
+    border-radius: 6px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .btn-group-responsive > .btn-group:last-child:not(:first-child) > .btn {
+    border-radius: 6px;
+    border-top-right-radius: 0;
+    border-top-left-radius: 0;
+  }
+}

--- a/src/site/tools/download.markdown
+++ b/src/site/tools/download.markdown
@@ -15,7 +15,7 @@ E.g. blue note before or after brew commands.
 
 # Getting Dart Is Easy!
 
-<div class="btn-group hero-hldr btn-group-justified os-choices" style="display: table;">
+<div class="btn-group-responsive btn-group hero-hldr btn-group-justified os-choices" style="display: table;">
   <div class="btn-group">
     <button type="button" class="btn btn-default btn-lg" id="windows">Windows (Vista, 7, 8)</button>
   </div>


### PR DESCRIPTION
I was showing off the new downloads page on my phone before realizing the OS chooser banner didn't look so great!

It starts cutting off "Windows (Vista, 7, 8)" at Bootstrap's "small screens" size, 768px. I looked around and saw requests for responsive button groups, but Bootstrap has not applied any of the suggestions. So `dart-style.css` got some fanciness, so that the chooser goes vertical on small screens.

Staged here: https://responsivize-new-dl-page-dot-dart-lang.appspot.com

The OS chooser should _not_ look different at large screens, but if you resize the browser window to be narrower than 768px, the chooser should go vertical. It looks pretty good.
