### PR TITLE
Make definition of allowed characters more precise

### DIFF
--- a/src/site/tools/pub/pubspec.markdown
+++ b/src/site/tools/pub/pubspec.markdown
@@ -82,8 +82,8 @@ Every package needs a name.  It's how other packages will refer to yours,
 and how it will appear to the world, should you publish it.
 
 It should be all lowercase, with underscores to separate words,
-`just_like_this`. Stick with basic Latin letters and Arabic digits:
-`[a-z0-9_]` and ensure that it's a valid Dart identifier (i.e. doesn't start
+`just_like_this`. Only basic Latin letters and Arabic digits are allowed in package names:
+`[a-z0-9_]`, also ensure that it's a valid Dart identifier (i.e. doesn't start
 with digits and isn't a reserved word).
 
 Try to pick a name that is clear, terse, and not already in use.


### PR DESCRIPTION
The current description could be more precise, "Stick with" can be read as a suggestion rather than a strict rule. It can lead to confusion such as the misunderstanding in this issue:
https://code.google.com/p/dart/issues/detail?id=21576
