### PR TITLE
fix broken tutorials link

### DIFF
--- a/src/site/codelabs/polymer/index.markdown
+++ b/src/site/codelabs/polymer/index.markdown
@@ -1687,7 +1687,7 @@ elements.
 on our [Samples page](/samples/).
 
 * Learn more about Dart from
-the [Dart tutorials](/tutorials/).
+the [Dart tutorials](/docs/tutorials/).
 
 * [A Tour of the Dart Language](/docs/dart-up-and-running/ch02.html)
 shows you how to use each major Dart feature,


### PR DESCRIPTION
in dart polymer codelab site, link to tutorials was missing /docs/
