### PR TITLE
fix dead link to args library

### DIFF
--- a/src/site/docs/dart-up-and-running/ch02.markdown
+++ b/src/site/docs/dart-up-and-running/ch02.markdown
@@ -912,7 +912,7 @@ void main(List<String> arguments) {
 }
 {% endprettify %}
 
-You can use the [args library](http://api.dartlang.org/args.html) to
+You can use the [args library](https://pub.dartlang.org/packages/args) to
 define and parse command-line arguments.
 
 


### PR DESCRIPTION
old link does not work. I guess it's this one.
