### PR TITLE
Docker commmand for printing variables on Windows

### DIFF
--- a/src/site/cloud/setup.markdown
+++ b/src/site/cloud/setup.markdown
@@ -311,7 +311,7 @@ to SSH into the VM instead.
 First, run the following command:
 
 <pre>
-> "%ProgramFiles%\Boot2Docker for Windows\boot2docker.exe" ssh
+> "%ProgramFiles%\Boot2Docker for Windows\boot2docker.exe" shellinit
 </pre>
 
 This prints three lines like this:


### PR DESCRIPTION
Command ssh does not print those three lines. The shellinit command does.
