### PR TITLE
Add sourceMaps to dart2js transformer options list.

### DIFF
--- a/src/site/tools/pub/dart2js-transformer.markdown
+++ b/src/site/tools/pub/dart2js-transformer.markdown
@@ -61,6 +61,7 @@ transformers:
     verbose: true
     environment: {name: value, ...}
     analyzeAll: true
+    sourceMaps: true
     suppressWarnings: true
     suppressHints: true
     terse: true


### PR DESCRIPTION
This covers functionality added in [r43536](https://code.google.com/p/dart/source/detail?r=43536) which allows developers to control whether or not source maps are emitted independent of the `--mode` flag. Related bug is [dartbug.com/22174](https://code.google.com/p/dart/issues/detail?id=22174).