### PR TITLE
First whack at improving the Publishing a Package page

### DIFF
--- a/src/site/tools/pub/publishing.markdown
+++ b/src/site/tools/pub/publishing.markdown
@@ -23,7 +23,7 @@ to [pub.dartlang.org](https://pub.dartlang.org). Pub will also show you all of
 the files it intends to "publish". Here's an example of publishing a package
 named `transmogrify`:
 
-{% prettify %}
+{% prettify none %}
 Publishing transmogrify 1.0.0 to https://pub.dartlang.org:
     .gitignore
     CHANGELOG.md

--- a/src/site/tools/pub/publishing.markdown
+++ b/src/site/tools/pub/publishing.markdown
@@ -59,31 +59,23 @@ dependencies:
 
 ## Important files
 
-When you publish your package to [pub.dartlang.org](https://pub.dartlang.org/),
-it gets its very own page at pub.dartlang.org/packages/<your_package>. This
-page uses content from files in your package, and contains several sections:
+Pub strictly uses the [package layout conventions](package-layout.html) to find
+files that will go into your projects Pub package. Review the conventions to
+understand what Pub will publish.
 
-* **README**: If your package includes a README file, then it will be shown as
-  the main content at your package's pub.dartlang.org URL.
+In particular, Pub uses the contents of a few files to create a page for your
+package at pub.dartlang.org/packages/<your_package>. Here are the files that
+will affect how your package's page will look:
 
-* **CHANGLOG**: If your package includes a CHANGELOG file, that will be listed
-  as one of the tabs at the top of the page.
-
-* **Installing**: The "Installing" tab is generated based on the latest version
-  of your package that has been published, giving users a nice recommendation
-  of how to include it in their `pubspec.yaml` file.
-
-* **Versions**: The "Versions" tab shows a history of all versions of your
-  package that have ever been published, with links to their documentation,
-  hosted at [dartdocs.org](https://dartdocs.org), and an archive `.tar.gz`
-  file.
-
-* **Sidebar**: The sidebar at your package's pub.dartlang.org URL includes
-  information drawn from your `pubspec.yaml` file, including the description,
-  author(s), homepage, documentation URL, and a list of uploaders.
-
-For more information about how to write your README and CHANGELOG, take a look
-at the [package layout conventions](package-layout.html).
+* **README**: The README file (`README`, `README.md`, `README.mdown`,
+  `README.markdown`) is the main content featured in your package's page.
+* **CHANGELOG**: Your package's CHANGELOG (`CHANGELOG`, `CHANGELOG.md`,
+  `CHANGELOG.mdown`, `CHANGELOG.markdown`), if found, will also be featured in a
+  tab on your package's page, so that developers can read it right from
+  pub.dartlang.org.
+* **The pubspec**: Your package's `pubspec.yaml` file is used to fill out
+  details about your package on the right-side of your package's page, like its
+  description, authors, etc.
 
 ## Publishing is forever
 

--- a/src/site/tools/pub/publishing.markdown
+++ b/src/site/tools/pub/publishing.markdown
@@ -12,7 +12,7 @@ It also allows you to share your packages with the world. If you have a useful
 project and you want others to be able to use it, use the `pub publish`
 command. For your first time around, you can perform a dry run like so:
 
-{% prettify sh %}
+{% prettify none %}
 $ pub publish --dry-run
 {% endprettify %}
 
@@ -40,14 +40,14 @@ Publishing transmogrify 1.0.0 to https://pub.dartlang.org:
 Package has 0 warnings.
 {% endprettify %}
 
-To publish your package for reals, remove the `--dry-run` argument:
+When you're ready to publish your package, remove the `--dry-run` argument:
 
-{% prettify sh %}
+{% prettify none %}
 $ pub publish
 {% endprettify %}
 
 After your package has been successfully uploaded to
-[pub.dartlang.org](https://pub.dartlang.org/), any Pub user will be able to
+[pub.dartlang.org](https://pub.dartlang.org/), any pub user will be able to
 download it or depend on it in their projects. For example, if you just
 published version 1.0.0 of your `transmogrify` package, then another Dart
 developer can add it as a dependency in their `pubspec.yaml`:
@@ -59,12 +59,11 @@ dependencies:
 
 ## Important files
 
-Pub strictly uses the [package layout conventions](package-layout.html) to find
-files that will go into your projects Pub package. Review the conventions to
-understand what Pub will publish.
+Pub will include all files in the current directory (excluding generated files,
+like `packages/, `test/packages/`, `pubspec.lock`) in the uploaded package.
 
-In particular, Pub uses the contents of a few files to create a page for your
-package at pub.dartlang.org/packages/<your_package>. Here are the files that
+Pub also uses the contents of a few files to create a page for your
+package at `pub.dartlang.org/packages/<your_package>`. Here are the files that
 will affect how your package's page will look:
 
 * **README**: The README file (`README`, `README.md`, `README.mdown`,
@@ -74,14 +73,14 @@ will affect how your package's page will look:
   tab on your package's page, so that developers can read it right from
   pub.dartlang.org.
 * **The pubspec**: Your package's `pubspec.yaml` file is used to fill out
-  details about your package on the right-side of your package's page, like its
+  details about your package on the right side of your package's page, like its
   description, authors, etc.
 
 ## Publishing is forever
 
 Keep in mind that publishing is forever. As soon as you publish your package,
 users will be able to depend on it. Once they start doing that, removing
-the package would break theirs. To avoid that, Pub strongly discourages
+the package would break theirs. To avoid that, pub strongly discourages
 deleting packages. You can always upload new versions of your package, but
 old ones will continue to be available for users that aren't ready to
 upgrade yet.

--- a/src/site/tools/pub/publishing.markdown
+++ b/src/site/tools/pub/publishing.markdown
@@ -7,29 +7,89 @@ title: "Publishing a Package"
 
 # {{ page.title }}
 
-[Pub](/tools/pub) isn't just for using other people's packages. It also allows you to share
-your packages with the world. Once you've written some useful code and you want
-everyone else to be able to use it, just run:
+[Pub](/tools/pub) isn't just for using other people's packages.
+It also allows you to share your packages with the world. If you have a useful
+project and you want others to be able to use it, use the `pub publish`
+command. For your first time around, you can perform a dry run like so:
+
+{% prettify sh %}
+$ pub publish --dry-run
+{% endprettify %}
+
+Pub will check to make sure that your package follows the
+[pubspec format](pubspec.html) and
+[package layout conventions](package-layout.html), and then upload your package
+to [pub.dartlang.org](https://pub.dartlang.org). Pub will also show you all of
+the files it intends to "publish". Here's an example of publishing a package
+named `transmogrify`:
+
+{% prettify %}
+Publishing transmogrify 1.0.0 to https://pub.dartlang.org:
+    .gitignore
+    CHANGELOG.md
+    README.md
+    lib
+        transmogrify.dart
+        src
+            transmogrifier.dart
+            transmogrification.dart
+    pubspec.yaml
+    test
+        transmogrify_test.dart
+
+Package has 0 warnings.
+{% endprettify %}
+
+To publish your package for reals, remove the `--dry-run` argument:
 
 {% prettify sh %}
 $ pub publish
 {% endprettify %}
 
-Pub will check to make sure that your package follows the [pubspec
-format](pubspec.html) and [package layout conventions](package-layout.html),
-and then upload your package to [pub.dartlang.org](http://pub.dartlang.org).
-Then any Pub user will be able to download it or depend on it in their
-pubspecs. For example, if you just published version 1.0.0 of a package named
-`transmogrify`, then they can write:
+After your package has been successfully uploaded to
+[pub.dartlang.org](https://pub.dartlang.org/), any Pub user will be able to
+download it or depend on it in their projects. For example, if you just
+published version 1.0.0 of your `transmogrify` package, then another Dart
+developer can add it as a dependency in their `pubspec.yaml`:
 
 {% prettify yaml %}
 dependencies:
   transmogrify: ">= 1.0.0 < 2.0.0"
 {% endprettify %}
 
+## Important files
+
+When you publish your package to [pub.dartlang.org](https://pub.dartlang.org/),
+it gets its very own page at pub.dartlang.org/packages/<your_package>. This
+page uses content from files in your package, and contains several sections:
+
+* **README**: If your package includes a README file, then it will be shown as
+  the main content at your package's pub.dartlang.org URL.
+
+* **CHANGLOG**: If your package includes a CHANGELOG file, that will be listed
+  as one of the tabs at the top of the page.
+
+* **Installing**: The "Installing" tab is generated based on the latest version
+  of your package that has been published, giving users a nice recommendation
+  of how to include it in their `pubspec.yaml` file.
+
+* **Versions**: The "Versions" tab shows a history of all versions of your
+  package that have ever been published, with links to their documentation,
+  hosted at [dartdocs.org](https://dartdocs.org), and an archive `.tar.gz`
+  file.
+
+* **Sidebar**: The sidebar at your package's pub.dartlang.org URL includes
+  information drawn from your `pubspec.yaml` file, including the description,
+  author(s), homepage, documentation URL, and a list of uploaders.
+
+For more information about how to write your README and CHANGELOG, take a look
+at the [package layout conventions](package-layout.html).
+
+## Publishing is forever
+
 Keep in mind that publishing is forever. As soon as you publish your package,
 users will be able to depend on it. Once they start doing that, removing
-the package would break theirs. To avoid that, pub strongly discourages
+the package would break theirs. To avoid that, Pub strongly discourages
 deleting packages. You can always upload new versions of your package, but
 old ones will continue to be available for users that aren't ready to
 upgrade yet.


### PR DESCRIPTION
Fixes #1251 

Staged: https://pub-publish-dot-dart-lang.appspot.com/tools/pub/publishing.html
