### PR TITLE
Fix #1280: mention preferred doc comment syntax and update links.

### DIFF
--- a/src/site/articles/doc-comment-guidelines/index.markdown
+++ b/src/site/articles/doc-comment-guidelines/index.markdown
@@ -36,6 +36,12 @@ See also these related articles:
 
 ## Examples
 
+Dart supports two syntaxes for doc comments (`///` and `/**`), but we
+prefer using `///`. The `///` is more compact. ('/**' and '*/' add two
+"blank" lines to a multiline doc comment). It is also easier to read
+in some situations, such as a doc comment that contains a Markdown list
+bulleted with `*`.
+
 Here's a typical comment for a function or method:
 
 <!-- BEGIN(min) -->{% prettify dart %}
@@ -58,9 +64,9 @@ And one for a variable or property:
 const double pi = 3.1415926535897932;
 {% endprettify %}<!-- END(PI) -->
 
-For an example of a class description with example code, see Completer
-([generated doc](http://api.dartlang.org/dart_async/Completer.html),
-[source code](http://code.google.com/p/dart/source/browse/branches/bleeding_edge/dart/sdk/lib/async/future.dart)).
+For an example of a library with doc comments, see the `path` library.
+([generated doc](http://www.dartdocs.org/documentation/path/1.3.3/index.html),
+[source code](https://github.com/dart-lang/path/blob/1.3.3/lib/path.dart)).
 
 
 ## Content

--- a/src/site/articles/doc-comment-guidelines/index.markdown
+++ b/src/site/articles/doc-comment-guidelines/index.markdown
@@ -36,12 +36,6 @@ See also these related articles:
 
 ## Examples
 
-Dart supports two syntaxes for doc comments (`///` and `/**`), but we
-prefer using `///`. The `///` is more compact. ('/**' and '*/' add two
-"blank" lines to a multiline doc comment). It is also easier to read
-in some situations, such as a doc comment that contains a Markdown list
-bulleted with `*`.
-
 Here's a typical comment for a function or method:
 
 <!-- BEGIN(min) -->{% prettify dart %}
@@ -65,9 +59,16 @@ const double pi = 3.1415926535897932;
 {% endprettify %}<!-- END(PI) -->
 
 For an example of a library with doc comments, see the `path` library.
-([generated doc](http://www.dartdocs.org/documentation/path/1.3.3/index.html),
+([generated doc](http://www.dartdocs.org/documentation/path/1.3.3/index.html#path/path),
 [source code](https://github.com/dart-lang/path/blob/1.3.3/lib/path.dart)).
 
+<aside class="alert alert-info" markdown="1">
+<b>Style note:</b>
+Dart supports two syntaxes for doc comments: `///` and `/**`.
+This document follows the
+[style guide recommendation](/articles/style-guide/#do-use-doc-comments-when-commenting-members-and-types)
+of using `///`. Older source code tends to use `/**`.
+</aside>
 
 ## Content
 

--- a/src/site/articles/style-guide/index.markdown
+++ b/src/site/articles/style-guide/index.markdown
@@ -835,8 +835,11 @@ Db
 {:.no_toc}
 <!-- https://github.com/dart-lang/www.dartlang.org/issues/668 -->
 
-Although Dart supports two syntaxes of doc comments (`///` and `/**`), we
-prefer using `///` for doc comments.
+Although Dart supports two syntaxes of doc comments (`///` and `/**`), we prefer
+using `///` for doc comments. The `///` is more compact. ('/**' and '*/' add two
+"blank" lines to a multiline doc comment.) It is also easier to read in some
+situations, such as a doc comment that contains a Markdown list bulleted with
+`*`.
 
 <div class="good">
 {% prettify dart %}


### PR DESCRIPTION
At Bob Nystrom's suggestion, instead of referencing Completer as a
good example of doc comments (it uses the /*\* syntax), reference
`path` instead, which is outside of `dart:core`.

For background, see: https://groups.google.com/a/dartlang.org/forum/#!topic/misc/KHScJ4nfL2s
