### PR TITLE
Add a server/client tutorial to the server menu and change title of command line tutorial

### DIFF
--- a/src/site/_includes/header.html
+++ b/src/site/_includes/header.html
@@ -151,7 +151,8 @@
               </a>
               <ul class="dropdown-menu">
                 <i class="sprite-icon-dd-tip"></i>
-                <li><a href="/docs/tutorials/cmdline/">Tutorial: Command-Line and Server Apps</a></li>
+                <li><a href="/docs/tutorials/cmdline/">Tutorial: Basic Command-Line Apps</a></li>
+                <li><a href="/docs/tutorials/httpserver/">Tutorial: HTTP Server and Clients</a></li>
 
                 <li class="divider"></li>
                 <li><a href="/server/google-cloud-platform/">Deploying your server application</a></li>


### PR DESCRIPTION
I found the http server/client tutorial to be more server specific and would like to include it in the server menu. I renamed the previous tutorial to not indicate it was related to servers.