### PR TITLE
Add Pick & School to Who Uses Dart

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -12,6 +12,9 @@ If you build production software with Dart, and want
 to be included in this list, please open a
 [pull request](https://github.com/dart-lang/www.dartlang.org/blob/master/src/site/community/who-uses-dart.markdown). Thanks!
 
+[Pick & School](https://www.picknschool.com)
+: An Online Catalog of studies in French Higher Education.
+
 [AdSense performance reports](http://adsense.blogspot.co.uk/2015/04/new-adsense-performance-reports.html)
 : With the redesigned Performance tab, you now have more control and flexibility, allowing you to better understand your AdSense earnings and performance.
 


### PR DESCRIPTION
We've just launched Pick & School ( https://www.picknschool.com ). The application frontEnd is written completely in Dart Language.