### PR TITLE
Update markdown doccomment example to follow style

### DIFF
--- a/src/site/effective-dart/documentation/index.markdown
+++ b/src/site/effective-dart/documentation/index.markdown
@@ -307,8 +307,10 @@ universal popularity is why we chose it. Here's just a quick example to give you
 a flavor of what's supported:
 
 {% prettify dart %}
-/// This is a paragraph of regular text. This sentence has *two* _emphasized_
-/// words (i.e. italics) and **two** __strong__ ones (bold).
+/// This is a paragraph of regular text.
+///
+/// This sentence has *two* _emphasized_ words (i.e. italics) and **two**
+/// __strong__ ones (bold).
 ///
 /// A blank line creates another separate paragraph. It has some `inline code`
 /// delimited using backticks.


### PR DESCRIPTION
The markdown doccomment example has two sentences before a line break; per style guidelines in this same file there should only be one sentence before the line break.