### PR TITLE
Update name

### DIFF
--- a/src/site/community/who-uses-dart.markdown
+++ b/src/site/community/who-uses-dart.markdown
@@ -35,8 +35,8 @@ In Dart - for Dart, for you!
 [EasyInsure](https://www.easy.insure)
 : EasyInsure is a Web application that allows searching the database of 190K+ insurance agents, see their ratings and specialities, rate the agents, and get instant insurance quotes online.
 
-[DartVoid](http://www.dartvoid.com)
-: Application hosting platform built and optimized for Dart. 
+[Sourcevoid](https://www.sourcevoid.com/)
+: Application hosting platform built and optimized for Dart. Cloud portal and homepage built with Dart, the homepage is server side rendered and the portal app is a single page Dart app backed by a Dart API. 
 
 Google internal sales tool
 : Built with AngularDart.


### PR DESCRIPTION
DartVoid no longer exists and have been replaced by Sourcevoid. I have also added a longer text on the name change at the bottom on this page if someone is curious on the details: https://www.sourcevoid.com/cloud/beta